### PR TITLE
ACM output to use cert validation resource

### DIFF
--- a/resource-groups/acm-certificate/outputs.tf
+++ b/resource-groups/acm-certificate/outputs.tf
@@ -1,4 +1,4 @@
 output "certificate_arn" {
   description = "ARN of the certificate created"
-  value       = aws_acm_certificate_validation.validation.arn
+  value       = aws_acm_certificate_validation.validation.certificate_arn
 }

--- a/resource-groups/acm-certificate/outputs.tf
+++ b/resource-groups/acm-certificate/outputs.tf
@@ -1,4 +1,4 @@
 output "certificate_arn" {
   description = "ARN of the certificate created"
-  value       = aws_acm_certificate_validation.cert.arn
+  value       = aws_acm_certificate_validation.validation.arn
 }

--- a/resource-groups/acm-certificate/outputs.tf
+++ b/resource-groups/acm-certificate/outputs.tf
@@ -1,4 +1,4 @@
 output "certificate_arn" {
   description = "ARN of the certificate created"
-  value       = aws_acm_certificate.cert.arn
+  value       = aws_acm_certificate_validation.cert.arn
 }


### PR DESCRIPTION
Ensures the certificate is validated before trying to create LB listeners. As per Terraform documentation here:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation#dns-validation-with-route-53