### PR TITLE
Relax ephemeral out NACL rules

### DIFF
--- a/modules/four-tier-vpc/subnet_application.tf
+++ b/modules/four-tier-vpc/subnet_application.tf
@@ -85,25 +85,14 @@ resource "aws_network_acl_rule" "application__deny_25565_everywhere_out" {
   to_port        = 25565
 }
 
-resource "aws_network_acl_rule" "application__allow_ephemeral_web_a_out" {
-  cidr_block     = local.subnet_cidr_blocks.web.a
+resource "aws_network_acl_rule" "application__allow_ephemeral_everywhere_out" {
+  cidr_block     = "0.0.0.0/0"
   egress         = true
   from_port      = 1024
   network_acl_id = aws_network_acl.application_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
   rule_number    = 5100
-  to_port        = 65535
-}
-
-resource "aws_network_acl_rule" "application__allow_ephemeral_web_b_out" {
-  cidr_block     = local.subnet_cidr_blocks.web.b
-  egress         = true
-  from_port      = 1024
-  network_acl_id = aws_network_acl.application_subnet.id
-  protocol       = "tcp"
-  rule_action    = "allow"
-  rule_number    = 5200
   to_port        = 65535
 }
 

--- a/modules/four-tier-vpc/subnet_database.tf
+++ b/modules/four-tier-vpc/subnet_database.tf
@@ -65,24 +65,13 @@ resource "aws_network_acl_rule" "database__deny_25565_everywhere_out" {
   to_port        = 25565
 }
 
-resource "aws_network_acl_rule" "database__allow_ephemeral_application_a_out" {
-  cidr_block     = local.subnet_cidr_blocks.application.a
+resource "aws_network_acl_rule" "database__allow_ephemeral_everywhere_out" {
+  cidr_block     = "0.0.0.0/0"
   egress         = true
   from_port      = 1024
   network_acl_id = aws_network_acl.database_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
   rule_number    = 5100
-  to_port        = 65535
-}
-
-resource "aws_network_acl_rule" "database__allow_ephemeral_application_b_out" {
-  cidr_block     = local.subnet_cidr_blocks.application.b
-  egress         = true
-  from_port      = 1024
-  network_acl_id = aws_network_acl.database_subnet.id
-  protocol       = "tcp"
-  rule_action    = "allow"
-  rule_number    = 5200
   to_port        = 65535
 }

--- a/modules/four-tier-vpc/subnet_web.tf
+++ b/modules/four-tier-vpc/subnet_web.tf
@@ -85,25 +85,14 @@ resource "aws_network_acl_rule" "web__deny_25565_everywhere_out" {
   to_port        = 25565
 }
 
-resource "aws_network_acl_rule" "web__allow_ephemeral_public_a_out" {
-  cidr_block     = local.subnet_cidr_blocks.public.a
+resource "aws_network_acl_rule" "web__allow_ephemeral_everywhere_out" {
+  cidr_block     = "0.0.0.0/0"
   egress         = true
   from_port      = 1024
   network_acl_id = aws_network_acl.web_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
   rule_number    = 5100
-  to_port        = 65535
-}
-
-resource "aws_network_acl_rule" "web__allow_ephemeral_public_b_out" {
-  cidr_block     = local.subnet_cidr_blocks.public.b
-  egress         = true
-  from_port      = 1024
-  network_acl_id = aws_network_acl.web_subnet.id
-  protocol       = "tcp"
-  rule_action    = "allow"
-  rule_number    = 5200
   to_port        = 65535
 }
 


### PR DESCRIPTION
Some of the subnets have ephemeral out restricted only to adjacent layers. This is over-restrictive and in fact tighter than the stipulations in [the AW recommendations](https://crowncommercialservice.atlassian.net/wiki/spaces/GPaaS/pages/3561685032/AWS+3+Tier+Reference+Architecture).

So each subnet will be altered to permit ephemeral port traffic to all addresses (disallowing :25565 of course).