### PR TITLE
Tweak error_message for validation on ElastiCache cluster_id

### DIFF
--- a/resource-groups/elasticache-redis/variables.tf
+++ b/resource-groups/elasticache-redis/variables.tf
@@ -3,7 +3,7 @@ variable "cluster_id" {
   description = "ID (name) to give"
   validation {
     condition     = can(regex("[a-z0-9\\-]+", var.cluster_id))
-    error_message = "The cluster_id can only contain lower case a-z, 0-9 and hyphens(-)"
+    error_message = "The cluster_id can only contain lower case a-z, 0-9 and hyphens(-)."
   }
 }
 


### PR DESCRIPTION
For compatibility with Terraform <1.2, this PR adjusts the `error_message` to begin with an uppercase character and end with a period.

Validation constraints were updated in Terraform 1.2 and above to mean that they do not throw errors themselves, but as CCS is familiar with running Terraform 1.0.11 we should remain backwards compatible here.