### PR TITLE
GMBP-238: Enable image scan on push

### DIFF
--- a/resource-groups/ecr-repository-group/main.tf
+++ b/resource-groups/ecr-repository-group/main.tf
@@ -1,7 +1,10 @@
 resource "aws_ecr_repository" "repo" {
-  for_each             = toset(var.repository_names)
-  name                 = each.value
-  force_delete         = var.is_ephemeral
+  for_each     = toset(var.repository_names)
+  name         = each.value
+  force_delete = var.is_ephemeral
+  image_scanning_configuration {
+    scan_on_push = true
+  }
   image_tag_mutability = "MUTABLE"
 
   encryption_configuration {
@@ -78,7 +81,7 @@ data "aws_iam_policy_document" "allow_push_from_jenkins_accounts" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         "473251818902", # Jenkins dev
         "974531504241"  # Jenkins prod


### PR DESCRIPTION
This is a small quality of life improvement to enable no cost, basic image scanning for CVEs on image upload.

It serves to give a visual indicator in the console of high, medium and low severity issues. It does not block or otherwise gate the image upload process. Importantly it is also one of the checks that Amazon GuardDuty (in use by CCS) evaluates against ECR repositories and is flagged up as a concern if not enabled.