### PR TITLE
GMBP-242: Prevent automatic minor version upgrades for PostgreSQL

### DIFF
--- a/resource-groups/rds-postgres/main.tf
+++ b/resource-groups/rds-postgres/main.tf
@@ -5,6 +5,7 @@ resource "aws_db_subnet_group" "subnet_group" {
 
 resource "aws_db_instance" "db" {
   allocated_storage               = var.allocated_storage_gb
+  auto_minor_version_upgrade      = false
   allow_major_version_upgrade     = false
   backup_retention_period         = var.backup_retention_period_days
   db_name                         = var.db_name # NB Postgres db names use underscores, not hyphens


### PR DESCRIPTION
To avoid mismatching source and target PostgreSQL DB engines during the migration from GPaaS, automatic minor version upgrades (alongside major version upgrades) should be disabled so as require manual upgrades where desired.