### PR TITLE
Add a watch timeout for the Postgres Migrations

### DIFF
--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -61,11 +61,11 @@ def run_migration(migrator_name):
         click.echo(f"Execution status: {execution_status}")
         if execution_status != "RUNNING":
             break
-        # Stop watching the Step Function after five minutes. The security token times out after 
+        # Stop watching the Step Function after two minutes. The security token times out after 
         # one hour and we don't want to keep Jenkins agents hanging around either.
-        if time.time() >= started + 300:
-            print('Task has been running for five minutes, please monitor Step Function in the AWS Console. Detaching...')
-            break
+        if time.time() >= started + 120:
+            print('Task has been running for two minutes, please monitor Step Function in the AWS Console. Detaching...')
+            sys.exit(0)
 
     if execution_status == "SUCCEEDED":
         click.echo("Success.")

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -53,6 +53,10 @@ def run_migration(migrator_name):
     execution_arn = execution_response["executionArn"]
     click.echo(f"Started execution {execution_arn}; waiting for termination.")
 
+    # Implement a timeout, so we only watch for say five minutes, then detach and print a message
+    # telling the user to observe the Step Function in the AWS Console.
+    # The security token times ouut after one hour and we don't want to keep Jenkins agents hanging 
+    # around either
     while True:
         time.sleep(5)
         execution_info = sfn_client.describe_execution(executionArn=execution_arn)

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -55,7 +55,7 @@ def run_migration(migrator_name):
 
     started = time.time()
     while True:
-        time.sleep(5)
+        time.sleep(30)
         execution_info = sfn_client.describe_execution(executionArn=execution_arn)
         execution_status = execution_info["status"]
         click.echo(f"Execution status: {execution_status}")

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -55,7 +55,7 @@ def run_migration(migrator_name):
 
     # Implement a timeout, so we only watch for say five minutes, then detach and print a message
     # telling the user to observe the Step Function in the AWS Console.
-    # The security token times ouut after one hour and we don't want to keep Jenkins agents hanging 
+    # The security token times out after one hour and we don't want to keep Jenkins agents hanging 
     # around either
     while True:
         time.sleep(5)

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -64,7 +64,7 @@ def run_migration(migrator_name):
         # Stop watching the Step Function after five minutes. The security token times out after 
         # one hour and we don't want to keep Jenkins agents hanging around either.
         if time.time() >= started + 300:
-            print('Task has been running for five minutes, please monitor Step Function in AWS Console. Detaching...')
+            print('Task has been running for five minutes, please monitor Step Function in the AWS Console. Detaching...')
             break
 
     if execution_status == "SUCCEEDED":

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -56,15 +56,15 @@ def run_migration(migrator_name):
     started = time.time()
     while True:
         time.sleep(5)
-        # Stop watching the Step Function after five minutes. The security token times out after 
-        # one hour and we don't want to keep Jenkins agents hanging around either.
-        if time.time() >= started + 300:
-            print('Task has been running for five minutes, please monitor Step Function in AWS Console. Detaching...')
-            break
         execution_info = sfn_client.describe_execution(executionArn=execution_arn)
         execution_status = execution_info["status"]
         click.echo(f"Execution status: {execution_status}")
         if execution_status != "RUNNING":
+            break
+        # Stop watching the Step Function after five minutes. The security token times out after 
+        # one hour and we don't want to keep Jenkins agents hanging around either.
+        if time.time() >= started + 300:
+            print('Task has been running for five minutes, please monitor Step Function in AWS Console. Detaching...')
             break
 
     if execution_status == "SUCCEEDED":

--- a/scripts/gpaas_postgres_migrator/run_migration.py
+++ b/scripts/gpaas_postgres_migrator/run_migration.py
@@ -53,12 +53,14 @@ def run_migration(migrator_name):
     execution_arn = execution_response["executionArn"]
     click.echo(f"Started execution {execution_arn}; waiting for termination.")
 
-    # Implement a timeout, so we only watch for say five minutes, then detach and print a message
-    # telling the user to observe the Step Function in the AWS Console.
-    # The security token times out after one hour and we don't want to keep Jenkins agents hanging 
-    # around either
+    started = time.time()
     while True:
         time.sleep(5)
+        # Stop watching the Step Function after five minutes. The security token times out after 
+        # one hour and we don't want to keep Jenkins agents hanging around either.
+        if time.time() >= started + 300:
+            print('Task has been running for five minutes, please monitor Step Function in AWS Console. Detaching...')
+            break
         execution_info = sfn_client.describe_execution(executionArn=execution_arn)
         execution_status = execution_info["status"]
         click.echo(f"Execution status: {execution_status}")


### PR DESCRIPTION
Don't hold on to the migration script indefinitely. Detach after five minutes