### PR TITLE
Add conduit app name

### DIFF
--- a/modules/gpaas-postgres-migrator/extract_task.tf
+++ b/modules/gpaas-postgres-migrator/extract_task.tf
@@ -21,7 +21,7 @@ module "extract_task" {
       # N.B. $DUMP_FILENAME is injected by the Step Function task
       override_command = [
         "sh", "-c",
-        "apk update && apk add --no-cache postgresql-client && cf install-plugin -f conduit && rm -rf $DUMP_FILENAME && cf login -a ${var.cf_config.api_endpoint} -u $CF_USERNAME -p $CF_PASSWORD -o ${var.cf_config.org} -s ${var.cf_config.space} && cf conduit ${var.cf_config.db_service_instance} -- pg_dump -j ${var.extract_task_pgdump_workers} -Fd --file $DUMP_FILENAME --no-acl --no-owner"
+        "apk update && apk add --no-cache postgresql-client && cf install-plugin -f conduit --app-name ${var.migrator_name}-pg-dump && rm -rf $DUMP_FILENAME && cf login -a ${var.cf_config.api_endpoint} -u $CF_USERNAME -p $CF_PASSWORD -o ${var.cf_config.org} -s ${var.cf_config.space} && cf conduit ${var.cf_config.db_service_instance} -- pg_dump -j ${var.extract_task_pgdump_workers} -Fd --file $DUMP_FILENAME --no-acl --no-owner"
       ]
       port = null
       # ECS Execution role will need access to these - see aws_iam_role_policy.ecs_execution_role__read_cf_creds_ssm

--- a/modules/gpaas-postgres-migrator/extract_task.tf
+++ b/modules/gpaas-postgres-migrator/extract_task.tf
@@ -21,7 +21,7 @@ module "extract_task" {
       # N.B. $DUMP_FILENAME is injected by the Step Function task
       override_command = [
         "sh", "-c",
-        "apk update && apk add --no-cache postgresql-client && cf install-plugin -f conduit --app-name ${var.migrator_name}-pg-dump && rm -rf $DUMP_FILENAME && cf login -a ${var.cf_config.api_endpoint} -u $CF_USERNAME -p $CF_PASSWORD -o ${var.cf_config.org} -s ${var.cf_config.space} && cf conduit ${var.cf_config.db_service_instance} -- pg_dump -j ${var.extract_task_pgdump_workers} -Fd --file $DUMP_FILENAME --no-acl --no-owner"
+        "apk update && apk add --no-cache postgresql-client && cf install-plugin -f conduit --app-name ccs-${var.migrator_name}-migration-pg-dump && rm -rf $DUMP_FILENAME && cf login -a ${var.cf_config.api_endpoint} -u $CF_USERNAME -p $CF_PASSWORD -o ${var.cf_config.org} -s ${var.cf_config.space} && cf conduit ${var.cf_config.db_service_instance} -- pg_dump -j ${var.extract_task_pgdump_workers} -Fd --file $DUMP_FILENAME --no-acl --no-owner"
       ]
       port = null
       # ECS Execution role will need access to these - see aws_iam_role_policy.ecs_execution_role__read_cf_creds_ssm


### PR DESCRIPTION
Use the `--app-name` so that the conduit connections are given meaningful names. This is so other users of conduit can know what is running and why. 

https://github.com/alphagov/paas-cf-conduit#conduit-apps

![image](https://github.com/Crown-Commercial-Service/ccs-migration-alpha-tools/assets/4614943/b72cdd9d-9014-48e2-852c-004a22e7057f)
