### PR TITLE
Add SSM parameter for PostgreSQL password

### DIFF
--- a/resource-groups/rds-postgres/db_password.tf
+++ b/resource-groups/rds-postgres/db_password.tf
@@ -3,11 +3,36 @@ resource "random_password" "db" {
   special = false
 }
 
+resource "aws_ssm_parameter" "postgres_connection_password" {
+  name        = "${var.db_name}-postgres-connection-password"
+  description = "The password for the ${var.db_name} PostgreSQL database"
+  type        = "SecureString"
+  value       = random_password.db.result
+}
+
 resource "aws_ssm_parameter" "postgres_connection_url" {
   name        = "${var.db_name}-postgres-connection-url"
   description = "Connection URL for the ${var.db_name} PostgreSQL database"
   type        = "SecureString"
   value       = "postgresql://${aws_db_instance.db.username}:${random_password.db.result}@${aws_db_instance.db.endpoint}/${aws_db_instance.db.db_name}"
+}
+
+data "aws_iam_policy_document" "read_postgres_connection_password_ssm" {
+  version = "2012-10-17"
+
+  statement {
+    sid = "AllowRead${replace(var.db_name, "/[-_/]/", "")}DbPasswordSecret"
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameters"
+    ]
+
+    resources = [
+      aws_ssm_parameter.postgres_connection_password.arn
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "read_postgres_connection_url_ssm" {

--- a/resource-groups/rds-postgres/outputs.tf
+++ b/resource-groups/rds-postgres/outputs.tf
@@ -46,6 +46,11 @@ output "db_connection_username" {
   value       = aws_db_instance.db.username
 }
 
+output "postgres_connection_password_ssm_parameter_arn" {
+  description = "ARN of the SSM parameter which contains the DB Connection password"
+  value       = aws_ssm_parameter.postgres_connection_password.arn
+}
+
 output "postgres_connection_url_ssm_parameter_arn" {
   description = "ARN of the SSM parameter which contains the DB Connection URL"
   value       = aws_ssm_parameter.postgres_connection_url.arn
@@ -54,6 +59,11 @@ output "postgres_connection_url_ssm_parameter_arn" {
 output "rds_db_endpoint" {
   description = "Endpoint to which to connect for access to this database"
   value       = aws_db_instance.db.endpoint
+}
+
+output "read_postgres_connection_password_ssm_policy_document_json" {
+  description = "JSON policy doc allowing read access to the DB Connection password parameter in SSM"
+  value       = data.aws_iam_policy_document.read_postgres_connection_password_ssm.json
 }
 
 output "read_postgres_connection_url_ssm_policy_document_json" {


### PR DESCRIPTION
Spring/JDBC appears not to support the `spring.datasource.url` containing credentials, and as such it is necessary to expose the username and password independently via `SPRING_DATASOURCE_USERNAME` and `SPRING_DATASOURCE_PASSWORD`. It's also not possible to manipulate the value of SSM parameters that are retrieved by ECS on our behalf (i.e. to parse out the password) hence the need to either:

- Store the password in a separate SSM parameter and reference it directly
- Expose the password via a plaintext environment variable

As the first route is preferable, this PR adds another SSM parameter to store just the master user's password. As the username isn't particularly secret we can just refer to this via the module outputs, i.e. `module.db.db_connection_username`.