### PR TITLE
Bump AWS provider to 5.26.0

### DIFF
--- a/modules/ecs-cluster/providers.tf
+++ b/modules/ecs-cluster/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/modules/four-tier-vpc/providers.tf
+++ b/modules/four-tier-vpc/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/modules/gpaas-postgres-migrator/providers.tf
+++ b/modules/gpaas-postgres-migrator/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/modules/gpaas-s3-migrator/providers.tf
+++ b/modules/gpaas-s3-migrator/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/modules/ithc-ingress-caution/providers.tf
+++ b/modules/ithc-ingress-caution/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/modules/locate-primary-vpc/providers.tf
+++ b/modules/locate-primary-vpc/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/acm-certificate/providers.tf
+++ b/resource-groups/acm-certificate/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/cloudwatch-log-group/providers.tf
+++ b/resource-groups/cloudwatch-log-group/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/deployed-lambda/providers.tf
+++ b/resource-groups/deployed-lambda/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/dmp-ecs-fargate-task-definition/providers.tf
+++ b/resource-groups/dmp-ecs-fargate-task-definition/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/ecr-repository-group/providers.tf
+++ b/resource-groups/ecr-repository-group/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/ecs-fargate-task-definition/providers.tf
+++ b/resource-groups/ecs-fargate-task-definition/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/elasticache-redis/providers.tf
+++ b/resource-groups/elasticache-redis/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/opensearch-domain/providers.tf
+++ b/resource-groups/opensearch-domain/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/private-s3-bucket/providers.tf
+++ b/resource-groups/private-s3-bucket/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }

--- a/resource-groups/rds-postgres/providers.tf
+++ b/resource-groups/rds-postgres/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.7.0"
+      version = ">=5.26.0"
     }
   }
 }


### PR DESCRIPTION
To see if it fixes this error:

```
│ Error: updating RDS DB Instance (rmiapi): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: ecb470e9-6a71-40b8-90bc-47aa33ce4003, api error InvalidParameterCombination: You can't specify storage throughput without IOPS for storage type gp3.
```