### PR TITLE
Remove redundant output from DMP-specific ECS task module

### DIFF
--- a/resource-groups/dmp-ecs-fargate-task-definition/README.md
+++ b/resource-groups/dmp-ecs-fargate-task-definition/README.md
@@ -5,7 +5,7 @@ Collection of resources to specify a Task Definition in Elastic Container Servic
 Includes (non-exhaustive):
 
 * Task Definition
-* Task Role and JSON document describing the IAM permission to pass the Task Role
+* Task Role
 
 There is a lot of commonality with the original ECS Task Definition resource group but the decision was taken _not_ to refactor them into a single module because it would introduce a lot of tightly-structured logic into a construct which (tbh) already stretches the idea of clear declarative code a little bit.
 

--- a/resource-groups/dmp-ecs-fargate-task-definition/outputs.tf
+++ b/resource-groups/dmp-ecs-fargate-task-definition/outputs.tf
@@ -1,8 +1,3 @@
-output "pass_task_role_policy_document_json" {
-  description = "JSON describing an IAM policy which allows passage of the task role"
-  value       = data.aws_iam_policy_document.pass_task_role.json
-}
-
 output "task_definition_arn" {
   description = "ARN of the task definition"
   value       = aws_ecs_task_definition.task.arn

--- a/resource-groups/dmp-ecs-fargate-task-definition/task_role.tf
+++ b/resource-groups/dmp-ecs-fargate-task-definition/task_role.tf
@@ -20,23 +20,3 @@ resource "aws_iam_role" "task_role" {
     ]
   })
 }
-
-
-data "aws_iam_policy_document" "pass_task_role" {
-  version = "2012-10-17"
-
-  statement {
-    sid = "Pass${replace(var.family_name, "/[-_]/", "")}TaskRole"
-    actions = [
-      "iam:GetRole",
-      "iam:PassRole"
-    ]
-    effect = "Allow"
-    resources = [
-      aws_iam_role.task_role.arn
-    ]
-  }
-  depends_on = [
-    aws_iam_role.task_role
-  ]
-}


### PR DESCRIPTION
See https://crowncommercialservice.atlassian.net/browse/GMBP-279

This is the limit of this solution's effect on the core repo: (see compare [my comment](https://github.com/Crown-Commercial-Service/ccs-migration-alpha-tools/pull/31#issuecomment-1829740289) on pull 31).

The affected module is only used in DMP. There will of course be a corresponding change on the DMP AWS repo once this PR is merged.