### PR TITLE
Fix cross-AZ traffic

### DIFF
--- a/modules/four-tier-vpc/subnet_application.tf
+++ b/modules/four-tier-vpc/subnet_application.tf
@@ -50,7 +50,7 @@ resource "aws_network_acl_association" "application_subnet" {
   subnet_id      = each.value
 }
 
-# Rules for servicing application service requests from services in web subnets
+# Rules for inbound traffic from the web subnets
 #
 resource "aws_network_acl_rule" "application__allow_http_web_a_in" {
   cidr_block     = local.subnet_cidr_blocks.web.a
@@ -70,7 +70,31 @@ resource "aws_network_acl_rule" "application__allow_http_web_b_in" {
   network_acl_id = aws_network_acl.application_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
+  rule_number    = 5001
+  to_port        = 80
+}
+
+# Rules for inbound traffic from the application subnets (think cross-AZ)
+#
+resource "aws_network_acl_rule" "application__allow_http_application_a_in" {
+  cidr_block     = local.subnet_cidr_blocks.application.a
+  egress         = false
+  from_port      = 80
+  network_acl_id = aws_network_acl.application_subnet.id
+  protocol       = "tcp"
+  rule_action    = "allow"
   rule_number    = 5100
+  to_port        = 80
+}
+
+resource "aws_network_acl_rule" "application__allow_http_application_b_in" {
+  cidr_block     = local.subnet_cidr_blocks.application.b
+  egress         = false
+  from_port      = 80
+  network_acl_id = aws_network_acl.application_subnet.id
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 5101
   to_port        = 80
 }
 

--- a/modules/four-tier-vpc/subnet_application.tf
+++ b/modules/four-tier-vpc/subnet_application.tf
@@ -83,7 +83,7 @@ resource "aws_network_acl_rule" "application__allow_http_application_a_in" {
   network_acl_id = aws_network_acl.application_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
-  rule_number    = 5100
+  rule_number    = 5002
   to_port        = 80
 }
 
@@ -94,7 +94,7 @@ resource "aws_network_acl_rule" "application__allow_http_application_b_in" {
   network_acl_id = aws_network_acl.application_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
-  rule_number    = 5101
+  rule_number    = 5003
   to_port        = 80
 }
 

--- a/modules/four-tier-vpc/subnet_web.tf
+++ b/modules/four-tier-vpc/subnet_web.tf
@@ -70,29 +70,7 @@ resource "aws_network_acl_rule" "web__allow_http_public_b_in" {
   network_acl_id = aws_network_acl.web_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
-  rule_number    = 5001
-  to_port        = 80
-}
-
-resource "aws_network_acl_rule" "web__allow_http_web_a_in" {
-  cidr_block     = local.subnet_cidr_blocks.web.a
-  egress         = false
-  from_port      = 80
-  network_acl_id = aws_network_acl.web_subnet.id
-  protocol       = "tcp"
-  rule_action    = "allow"
-  rule_number    = 5002
-  to_port        = 80
-}
-
-resource "aws_network_acl_rule" "web__allow_http_web_b_in" {
-  cidr_block     = local.subnet_cidr_blocks.web.b
-  egress         = false
-  from_port      = 80
-  network_acl_id = aws_network_acl.web_subnet.id
-  protocol       = "tcp"
-  rule_action    = "allow"
-  rule_number    = 5003
+  rule_number    = 5100
   to_port        = 80
 }
 

--- a/modules/four-tier-vpc/subnet_web.tf
+++ b/modules/four-tier-vpc/subnet_web.tf
@@ -70,7 +70,29 @@ resource "aws_network_acl_rule" "web__allow_http_public_b_in" {
   network_acl_id = aws_network_acl.web_subnet.id
   protocol       = "tcp"
   rule_action    = "allow"
-  rule_number    = 5100
+  rule_number    = 5001
+  to_port        = 80
+}
+
+resource "aws_network_acl_rule" "web__allow_http_web_a_in" {
+  cidr_block     = local.subnet_cidr_blocks.web.a
+  egress         = false
+  from_port      = 80
+  network_acl_id = aws_network_acl.web_subnet.id
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 5002
+  to_port        = 80
+}
+
+resource "aws_network_acl_rule" "web__allow_http_web_b_in" {
+  cidr_block     = local.subnet_cidr_blocks.web.b
+  egress         = false
+  from_port      = 80
+  network_acl_id = aws_network_acl.web_subnet.id
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 5003
   to_port        = 80
 }
 


### PR DESCRIPTION
ECS tasks should be deployable in either of the configured AZs. This PR ensures services can talk to each other cross-AZ, otherwise the NACLs deny inbound traffic from APP A Subnet to APP B Subnet and vice versa. 