### PR TITLE
Ignore recurring lifecycle change for OpenSearch domain

### DIFF
--- a/resource-groups/opensearch-domain/main.tf
+++ b/resource-groups/opensearch-domain/main.tf
@@ -40,6 +40,13 @@ resource "aws_opensearch_domain" "domain" {
     aws_iam_service_linked_role.opensearch
   ]
 
+  lifecycle {
+    ignore_changes = [
+      # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/27371
+      advanced_options["override_main_response_version"]
+    ]
+  }
+
   tags = {
     Domain = var.domain_name
   }


### PR DESCRIPTION
This ignores the changes continually proposed by Terraform regarding the override_main_response_version param