### PR TITLE
ECS update service - increase max attempts

### DIFF
--- a/scripts/update_service/update_service.py
+++ b/scripts/update_service/update_service.py
@@ -91,7 +91,7 @@ def update_service(tf_outputs_json, service_name, scale_to, redeploy, skip_wait)
     waiter.wait(
         cluster=ecs_cluster_arn,
         services=[service_name],
-        WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+        WaiterConfig={"Delay": 10, "MaxAttempts": 90},
     )
     click.echo("Done")
 

--- a/scripts/update_service/update_service.py
+++ b/scripts/update_service/update_service.py
@@ -91,7 +91,7 @@ def update_service(tf_outputs_json, service_name, scale_to, redeploy, skip_wait)
     waiter.wait(
         cluster=ecs_cluster_arn,
         services=[service_name],
-        WaiterConfig={"Delay": 10, "MaxAttempts": 50},
+        WaiterConfig={"Delay": 10, "MaxAttempts": 60},
     )
     click.echo("Done")
 


### PR DESCRIPTION
ECS takes much longer to drain an old service with Service Connect and TLS enabled. This does not affect how long it takes to bring a new deployment into service. 