### PR TITLE
Extend CloudWatch Dashboard to allow EC2 metrics

### DIFF
--- a/resource-groups/cloudwatch-dashboard/cloudwatch_dashboard.tf
+++ b/resource-groups/cloudwatch-dashboard/cloudwatch_dashboard.tf
@@ -371,6 +371,60 @@ resource "aws_cloudwatch_dashboard" "cloudwatch_dashboard" {
             "view": "timeSeries"
           }
         },
+        {
+          type: "metric",
+          properties: {
+            "metrics": [
+              for ec2_instance_id in var.ec2_instance_ids : [
+                "AWS/EC2",
+                "CPUUtilization",
+                "InstanceId",
+                ec2_instance_id,
+              ]
+            ],
+            "period": 60
+            "region": var.region,
+            "stacked": false,
+            "title": "ec2_instances_cpu_utilization",
+            "view": "timeSeries"
+        }
+      },
+      {
+        type: "metric",
+        properties: {
+          "metrics": [
+            for ec2_instance_id in var.ec2_instance_ids : [
+              "AWS/EC2",
+              "NetworkIn",
+              "InstanceId",
+              ec2_instance_id,
+            ]
+          ],
+          "period": 60
+          "region": var.region,
+          "stacked": false,
+          "title": "ec2_instances_network_in",
+          "view": "timeSeries"
+        }
+      },
+      {
+        type: "metric",
+        properties: {
+          "metrics": [
+            for ec2_instance_id in var.ec2_instance_ids : [
+              "AWS/EC2",
+              "NetworkOut",
+              "InstanceId",
+              ec2_instance_id,
+            ]
+          ],
+          "period": 60
+          "region": var.region,
+          "stacked": false,
+          "title": "ec2_instances_network_out",
+          "view": "timeSeries"
+        }
+      },
       ]
     }
   )

--- a/resource-groups/cloudwatch-dashboard/variables.tf
+++ b/resource-groups/cloudwatch-dashboard/variables.tf
@@ -13,6 +13,11 @@ variable "region" {
   type        = string
 }
 
+variable "ec2_instance_ids" {
+  description = "The ID(s) of the EC2 instances you wish to monitor (must be in list format)"
+  type        = list(string)
+}
+
 variable "ecs_service_names" {
   description = "The name(s) of the ECS Services you wish to monitor (must be in list format)"
   type        = list(string)


### PR DESCRIPTION
- Add variable for EC2 instance ID(s)
- Update CloudWatch Dashboard to present metrics for: CPU Utilisation, NetworkIn and NetworkOut